### PR TITLE
Presenting same evidence twice will no longer clear it

### DIFF
--- a/include/aoevidencedisplay.h
+++ b/include/aoevidencedisplay.h
@@ -19,6 +19,7 @@ public:
   void reset();
   void combo_resize(int w, int h);
 
+  int last_evidence_index = -1;
 signals:
   void show_evidence_details(int index);
 
@@ -27,7 +28,6 @@ private:
   InterfaceLayer *evidence_movie;
   QPushButton *evidence_icon;
   AOSfxPlayer *sfx_player;
-  int last_evidence_index = -1;
 
 private slots:
   void show_done();

--- a/src/aoevidencedisplay.cpp
+++ b/src/aoevidencedisplay.cpp
@@ -66,6 +66,7 @@ void AOEvidenceDisplay::reset()
   evidence_movie->kill();
   evidence_icon->hide();
   this->clear();
+  last_evidence_index = -1;
 }
 
 void AOEvidenceDisplay::show_done() { evidence_icon->show(); }

--- a/src/courtroom.cpp
+++ b/src/courtroom.cpp
@@ -2654,7 +2654,9 @@ void Courtroom::unpack_chatmessage(QStringList p_contents)
   evidence_presented = false;
   ui_vp_objection->stop();
   chat_tick_timer->stop();
-  ui_vp_evidence_display->reset();
+  if (ui_vp_evidence_display->last_evidence_index != m_chatmessage[EVIDENCE_ID].toInt())
+    ui_vp_evidence_display->reset();
+
   // This chat msg is not objection so we're not waiting on the objection animation to finish to display the character.
   if (!handle_objection())
     handle_ic_message();
@@ -2748,7 +2750,7 @@ void Courtroom::log_chatmessage(QString f_message, int f_char_id, QString f_show
     }
 
     // If the evidence ID is in the valid range
-    if (f_evi_id > 0 && f_evi_id <= local_evidence_list.size()) {
+    if (f_evi_id != ui_vp_evidence_display->last_evidence_index && f_evi_id > 0 && f_evi_id <= local_evidence_list.size()) {
       blankpost = false;
       // Obtain the evidence name
       QString f_evi_name = local_evidence_list.at(f_evi_id - 1).name;
@@ -3483,6 +3485,9 @@ void Courtroom::display_evidence_image()
 {
   QString side = m_chatmessage[SIDE];
   int f_evi_id = m_chatmessage[EVIDENCE_ID].toInt();
+  if (current_side == side && f_evi_id == ui_vp_evidence_display->last_evidence_index)
+    return;
+
   if (f_evi_id > 0 && f_evi_id <= local_evidence_list.size()) {
     // shifted by 1 because 0 is no evidence per legacy standards
     QString f_image = local_evidence_list.at(f_evi_id - 1).image;

--- a/src/evidence.cpp
+++ b/src/evidence.cpp
@@ -490,7 +490,8 @@ void Courtroom::on_evidence_double_clicked(int p_id)
 
   // We have to check if the ID is on the currently displayed page.
   // This is because SOMEONE allowed the switching of pages while evidence is still being edited.
-  if (p_id < ui_evidence_list.count()) {
+  // p_id is also going to be a negative number if it's not the currently d isplayed page
+  if (p_id >= 0 && p_id < ui_evidence_list.count()) {
     ui_evidence_list.at(p_id)->set_selected(true);
   }
   current_evidence = f_real_id;
@@ -577,13 +578,17 @@ void Courtroom::on_evidence_delete_clicked()
   else {
     local_evidence_list.remove(current_evidence);
     private_evidence_list = local_evidence_list;
-    set_evidence_page();
-
     // Autosave private evidence
     evidence_save("inventories/autosave.ini");
   }
+  current_evidence_page = current_evidence / max_evidence_on_page;
+  set_evidence_page();
 
-  current_evidence = 0;
+  current_evidence = qMax(0, current_evidence - 1);
+
+  // Display the target evidence using the local ID
+  int p_id = current_evidence - (max_evidence_on_page * current_evidence_page);
+  on_evidence_double_clicked(p_id);
 }
 
 bool Courtroom::on_evidence_x_clicked()


### PR DESCRIPTION
This way, you can present the same piece of evidence over multiple messages, and it won't disappear.
Viewing evidence on previous page will no longer crash if evidence list is updated
Pressing "Delete" will now set the evidence before it for viewing