### PR TITLE
Have sensible defaults for the settings options

### DIFF
--- a/src/options.cpp
+++ b/src/options.cpp
@@ -399,7 +399,7 @@ void Options::setColorLogEnabled(bool value)
 
 bool Options::clearSoundsDropdownOnPlayEnabled() const
 {
-  return config.value("stickysounds", true).toBool();
+  return config.value("stickysounds", false).toBool();
 }
 
 void Options::setClearSoundsDropdownOnPlayEnabled(bool value)
@@ -409,7 +409,7 @@ void Options::setClearSoundsDropdownOnPlayEnabled(bool value)
 
 bool Options::clearEffectsDropdownOnPlayEnabled() const
 {
-  return config.value("stickyeffects", true).toBool();
+  return config.value("stickyeffects", false).toBool();
 }
 
 void Options::setClearEffectsDropdownOnPlayEnabled(bool value)
@@ -419,7 +419,7 @@ void Options::setClearEffectsDropdownOnPlayEnabled(bool value)
 
 bool Options::clearPreOnPlayEnabled() const
 {
-  return config.value("stickypres", true).toBool();
+  return config.value("stickypres", false).toBool();
 }
 
 void Options::setClearPreOnPlayEnabled(bool value)
@@ -521,7 +521,7 @@ void Options::setAnimatedThemeEnabled(bool value)
 
 QString Options::defaultScalingMode() const
 {
-  return config.value("default_scaling", "fast").toString();
+  return config.value("default_scaling", "smooth").toString();
 }
 
 void Options::setDefaultScalingMode(QString value)
@@ -561,7 +561,7 @@ void Options::setPlaySelectedSFXOnIdle(bool value)
 
 bool Options::evidenceDoubleClickEdit() const
 {
-  return config.value("evidence_double_click", true).toBool();
+  return config.value("evidence_double_click", false).toBool();
 }
 
 void Options::setEvidenceDoubleClickEdit(bool value)

--- a/src/widgets/aooptionsdialog.cpp
+++ b/src/widgets/aooptionsdialog.cpp
@@ -487,8 +487,8 @@ void AOOptionsDialog::setupUI()
 
   // Populate scaling dropdown. This is necessary as we need the user data
   // embeeded into the entry.
-  ui_scaling_combobox->addItem(tr("Pixel"), "fast");
-  ui_scaling_combobox->addItem(tr("Smooth"), "smooth");
+  ui_scaling_combobox->addItem("pixel", "pixel");
+  ui_scaling_combobox->addItem("smooth", "smooth");
 
   registerOption<QCheckBox, bool>("shake_cb", &Options::shakeEnabled,
                                   &Options::setShakeEnabled);


### PR DESCRIPTION
DOUBLE-CLICK ON EVIDENCE IS DUMB
WHY ARE ALL "STICKY" OPTIONS ENABLED BY DEFAULT WHO DID THAT
WHY IS THE DEFAULT SCALING "FAST" (WHICH IS NOT EVEN A VALID OPTION BTW IT'S "PIXEL")
PIXEL/SMOOTH OPTION LITERALLY STOPPED WORKING AAAAAAAAAAAAAAAAAAA